### PR TITLE
add libpnetcdf to requirements

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set build = 2 %}
+{% set build = 3 %}
 {% set name = "lammps" %}
 {% set version = "patch_7Feb2024_update1" %}
 {% set version_plugins = "stable_2Aug2023" %}
@@ -84,6 +84,8 @@ requirements:
     - liblapack  # [linux]
     - libnetcdf
     - libnetcdf * {{ mpi_prefix }}_*
+    - libpnetcdf
+    - libpnetcdf * {{ mpi_prefix }}_*
     - kim-api
     - libcurl
     - mpi4py  # [mpi != 'nompi']


### PR DESCRIPTION
This prevents https://github.com/conda-forge/lammps-feedstock/issues/199 in the coming versions. Old versions should be patched in https://github.com/conda-forge/conda-forge-repodata-patches-feedstock.